### PR TITLE
Skip the condition when read() returns 0 in shell demo

### DIFF
--- a/demos/shell/shell.c
+++ b/demos/shell/shell.c
@@ -233,10 +233,10 @@ static void command_loop(int input) {
   while (1) {
     // -1 for null terminator space
     ssize_t got = read(input, &state.in, INPUT_BUFFER_SIZE - 1);
-    assert((got != 0) && "stdin closed!");
 
-    // got = 1 + size of read seems to mean nothing read
-    if (got == INPUT_BUFFER_SIZE) {
+    // in qemu 2, got = 1 + size of read seems to mean nothing read
+    // qemu version >=4 returns 0 when nothing is read
+    if (!got || got == INPUT_BUFFER_SIZE) {
       continue;
     }
 


### PR DESCRIPTION
Try to fix #4.

According to the description of `SYS_READ` of semihosting for aarch32
and aarch64:

   * If the return value is 0, the buffer had been filled successfully
   * If the return value equals to the 3rd argument of `read()`, it
      means no bytes were read.

Since we only need to deal with the condition when the return value is 
smaller than the 3rd argument we passed, we can skip the condition when
the above situations occur.


This commit had been tested on the targets: 
* `arm`
* `aarch64`
* `thumb`

compiled by the tool chains below 

```
aarch64-none-elf-gcc (GNU Toolchain for the A-profile Architecture 9.2-2019.12 (arm-9.10)) 9.2.1 20191025
arm-none-eabi-gcc (GNU Arm Embedded Toolchain 9-2020-q2-update) 9.3.1 20200408 (release)
```

and can work properly in both QEMU 5.1 and QEMU 4.2.1