### PR TITLE
Remove k_close in k_stdout_isatty

### DIFF
--- a/src/kernel/file.c
+++ b/src/kernel/file.c
@@ -50,7 +50,8 @@ bool k_stdout_isatty(void) {
   }
 
   int istty = k_isatty(stdout_fd);
-  k_close(stdout_fd);
+  // Closing stdout_fd may cause QEMU 4.2.1 to close its stdout
+  // So we just leave it opened here
 
   return istty == 1;
 }


### PR DESCRIPTION
Fix #10.

It is a workaround to avoid the outputting error in QEMU 4.2.1.

Since the stdout of QEMU may be closed when we close the stdout in
our guest platform, we leave the stdout opened to make sure that the
stdin/stdout are still available to use.

This commit has been tested in QEMU 5.1.0 and QEMU 4.2.1 and both of them run properly. 