### PR TITLE
Make Arm semihosting support optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set( OPT_LEVEL "3" CACHE STRING "Compiler optmisation level." )
 option( SANITIZERS "Enable UBSAN" OFF )
 option( LTO "Enable link time optimisation." OFF )
 option( CCACHE "Enable ccache." ON )
+set( SEMIHOSTING ON )
 set( STACK_SIZE 2 ) # In KB
 set( RAM_SIZE 0x100000 ) # 1MB in bytes
 
@@ -48,6 +49,7 @@ message(STATUS "SANITIZERS are ${SANITIZERS}")
 message(STATUS "LTO is ${LTO}")
 message(STATUS "COVERAGE is ${COVERAGE}")
 message(STATUS "STACK_SIZE is ${STACK_SIZE}KB")
+message(STATUS "SEMIHOSTING is ${SEMIHOSTING}")
 
 if(CCACHE)
   find_program(CCACHE_FOUND ccache)
@@ -90,6 +92,10 @@ endif()
 if(SANITIZERS)
   set( CFLAGS "${CFLAGS} -fsanitize=undefined" )
 endif(SANITIZERS)
+
+if(SEMIHOSTING)
+  set( CFLAGS "${CFLAGS} -DSEMIHOSTING_ENABLED" )
+endif(SEMIHOSTING)
 
 set( CMAKE_C_FLAGS "${PLATFORM} ${CFLAGS} -std=gnu11" )
 set( CMAKE_CXX_FLAGS "${PLATFORM} ${CFLAGS} -fno-rtti -fno-exceptions -fno-unwind-tables -std=c++11" )

--- a/src/hw/arm_common/port.c
+++ b/src/hw/arm_common/port.c
@@ -17,6 +17,7 @@ void do_svc(SVCCode code) {
 }
 
 size_t generic_semihosting_call(size_t operation, size_t* parameters) {
+#ifdef SEMIHOSTING_ENABLED
   size_t ret;
   // We assume that we're already in kernel mode by this point
   asm volatile("mov " RCHR "0, %[operation]\n\t"
@@ -27,6 +28,11 @@ size_t generic_semihosting_call(size_t operation, size_t* parameters) {
                : [ parameters ] "r"(parameters), [ operation ] "r"(operation)
                : RCHR "0", RCHR "1", "memory");
   return ret;
+#else
+  (void)operation;
+  (void)parameters;
+  return -1;
+#endif
 }
 
 size_t generic_syscall(Syscall num, size_t arg1, size_t arg2, size_t arg3,

--- a/src/kernel/semihosting.c
+++ b/src/kernel/semihosting.c
@@ -1,4 +1,5 @@
 #include "kernel/semihosting.h"
+#include "common/print.h"
 
 // Arm semihosting routines
 // platform specific asm in generic_semihosting_call
@@ -21,5 +22,12 @@ void k_exit(int status) {
   size_t* parameters = (size_t*)event;
 #endif
   generic_semihosting_call(SYS_EXIT, parameters);
+#ifdef SEMIHOSTING_ENABLED
   __builtin_unreachable();
+#else
+  (void)status;
+  printf("Exiting kernel\n");
+  while (1) {
+  }
+#endif
 }


### PR DESCRIPTION
In this patch, I add an new option in CMakeLists file to control whether
the semihosting feature should be turned on or off.

If semihosting has been disabled, the exit syscall will print out
"Exiting kernel" and hang in a while-loop. waiting the user to exit
manually.

Semihosting feature may not be provided by some devices. (e.g. Raspberry Pi)

I am currently working on porting AMT onto Raspberry Pi 4B, running 
semihosting may cause the board halted. So I think we should provide an extra
setting to control this feature.