### PR TITLE
Create option of link script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ option( LTO "Enable link time optimisation." OFF )
 option( CCACHE "Enable ccache." ON )
 set( STACK_SIZE 2 ) # In KB
 set( RAM_SIZE 0x100000 ) # 1MB in bytes
+set( LINKER_SCRIPT "kernel.ld" )
 
 string( TOLOWER "${BUILD_PLATFORM}" BP_LOWER )
 
@@ -48,6 +49,7 @@ message(STATUS "SANITIZERS are ${SANITIZERS}")
 message(STATUS "LTO is ${LTO}")
 message(STATUS "COVERAGE is ${COVERAGE}")
 message(STATUS "STACK_SIZE is ${STACK_SIZE}KB")
+message(STATUS "LINKER_SCRIPT is ${LINKER_SCRIPT}")
 
 if(CCACHE)
   find_program(CCACHE_FOUND ccache)

--- a/cmake/AddDemo.cmake
+++ b/cmake/AddDemo.cmake
@@ -14,7 +14,7 @@ function(__add_demo NAME TEST_TYPE MAX_THREADS)
   add_executable ( ${NAME} demos/${NAME}/${NAME}.c ${KERNEL_SOURCES} )
   target_compile_definitions(${NAME} PRIVATE MAX_THREADS=${MAX_THREADS})
 
-  target_link_libraries(${NAME} PRIVATE "-Wl,-T,${CMAKE_SOURCE_DIR}/linker/kernel.ld,-defsym=ram_start=${RAM_START},-defsym=ram_size=${RAM_SIZE},-lgcc,-lc,-N,--build-id=none")
+  target_link_libraries(${NAME} PRIVATE "-Wl,-T,${CMAKE_SOURCE_DIR}/linker/${LINKER_SCRIPT},-defsym=ram_start=${RAM_START},-defsym=ram_size=${RAM_SIZE},-lgcc,-lc,-N,--build-id=none")
 
   add_custom_command(TARGET ${NAME} PRE_BUILD
     COMMAND eval "${CMAKE_C_COMPILER} --version | head -n 1"


### PR DESCRIPTION
In this patch, we create a new option in cmake to let us change link scripts.

Since there is a different address map on Raspberry Pi, I think we should provide such an option.
We can then replace the original one when we want to build the kernel for Raspberry Pi.