### PR TITLE
Split the implementation of putchar from printf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set( SEMIHOSTING ON )
 set( STACK_SIZE 2 ) # In KB
 set( RAM_SIZE 0x100000 ) # 1MB in bytes
 set( LINKER_SCRIPT "kernel.ld" )
+set( SERIAL_DRIVER "virt_serial.c" )
 
 string( TOLOWER "${BUILD_PLATFORM}" BP_LOWER )
 
@@ -19,7 +20,6 @@ if( BP_LOWER STREQUAL "arm" )
   set( PLATFORM     "-mcpu=cortex-a15" )
   set( PLATFORM_SRC "arm_virt" )
   set( RAM_START    "0x40000000" )
-  set( UART_BASE    "0x09000000" )
   set( QEMU_CMD     "qemu-system-arm -M virt -cpu cortex-a15" )
 elseif( BP_LOWER STREQUAL "aarch64" )
   set( PREFIX       "aarch64-none-elf-" )
@@ -27,7 +27,6 @@ elseif( BP_LOWER STREQUAL "aarch64" )
   set( PLATFORM     "-mcpu=cortex-a57 -mgeneral-regs-only" )
   set( PLATFORM_SRC "aarch64_virt" )
   set( RAM_START    "0x40000000" )
-  set( UART_BASE    "0x09000000" )
   set( QEMU_CMD     "qemu-system-aarch64 -M virt -cpu cortex-a57" )
   # O3 LTO UBSAN trace demo needs some extra
   set( STACK_SIZE 3 )
@@ -37,7 +36,6 @@ elseif( BP_LOWER STREQUAL "thumb" )
   set( PLATFORM_SRC "thumb_lm3s6965evb" )
   set( RAM_START    "0x20000000" )
   set( RAM_SIZE     0x10000)
-  set( UART_BASE    "0x4000C000" )
   set( QEMU_CMD     "qemu-system-arm -M lm3s6965evb -cpu cortex-m4" )
 else()
   message(FATAL_ERROR "Invalid platform \"${BP_LOWER}\". \
@@ -52,6 +50,7 @@ message(STATUS "COVERAGE is ${COVERAGE}")
 message(STATUS "STACK_SIZE is ${STACK_SIZE}KB")
 message(STATUS "SEMIHOSTING is ${SEMIHOSTING}")
 message(STATUS "LINKER_SCRIPT is ${LINKER_SCRIPT}")
+message(STATUS "SERIAL_DRIVER is ${SERIAL_DRIVER}")
 
 if(CCACHE)
   find_program(CCACHE_FOUND ccache)
@@ -85,7 +84,7 @@ endif()
 
 # -fno-common to disallow variables being present in multiple compliaton units
 set( CFLAGS "${CFLAGS} -ffreestanding -nostdlib -fno-common" )
-add_definitions(-DUART_BASE=${UART_BASE} -DSRC_ROOT=\"${CMAKE_SOURCE_DIR}\" )
+add_definitions( -DSRC_ROOT=\"${CMAKE_SOURCE_DIR}\" )
 
 if(LTO)
   set( CFLAGS "${CFLAGS} -flto -ffunction-sections" )
@@ -122,6 +121,8 @@ set( KERNEL_SOURCES
   src/hw/${PLATFORM_SRC}/startup.s
   src/hw/${PLATFORM_SRC}/yield.S
   src/hw/${PLATFORM_SRC}/port.c
+
+  src/hw/driver/${SERIAL_DRIVER}
 
   src/common/print.cpp
   src/common/trace.c

--- a/include/common/serial_port.h
+++ b/include/common/serial_port.h
@@ -1,0 +1,11 @@
+#ifndef COMMON_SERIAL_PORT
+#define COMMON_SERIAL_PORT
+
+typedef struct {
+  void (*init)(void);
+  void (*putchar)(int);
+} SerialPort;
+
+extern SerialPort serial_port;
+
+#endif /* COMMON_SERIAL_PORT */

--- a/src/common/print.cpp
+++ b/src/common/print.cpp
@@ -1,4 +1,5 @@
 #include "common/print.h"
+#include "common/serial_port.h"
 #include "common/thread.h"
 #include <ctype.h>
 #include <stdint.h>
@@ -13,6 +14,7 @@ extern "C" void __cxa_pure_virtual() {
 
 class PrintOutput {
 public:
+  PrintOutput() {}
   explicit PrintOutput(char* out) : m_out(out) {}
 
   virtual void write(int chr) const = 0;
@@ -47,12 +49,12 @@ protected:
 
 class SerialPrintOutput : public PrintOutput {
 public:
-  SerialPrintOutput() : PrintOutput(reinterpret_cast<char*>(UART_BASE)) {}
+  SerialPrintOutput() {
+    serial_port.init();
+  }
 
   void write(int chr) const final {
-    volatile uint32_t* const UART0 = (uint32_t*)m_out;
-    *UART0 = (uint32_t)chr;
-    // We do not modify buf here, serial port doesn't move
+    serial_port.putchar(chr);
   }
 };
 

--- a/src/hw/driver/virt_serial.c
+++ b/src/hw/driver/virt_serial.c
@@ -1,0 +1,27 @@
+#include "common/serial_port.h"
+#include <stdint.h>
+
+#ifdef __aarch64__
+#define UART_BASE 0x09000000
+#elif defined __thumb__
+#define UART_BASE 0x4000C000
+#elif defined __arm__
+#define UART_BASE 0x09000000
+#else
+#error No virt serial port address for this architecture!
+#endif
+
+static volatile uint32_t* const UART0 = (uint32_t*)UART_BASE;
+
+static void virt_serial_init() {
+  // In QEMU, we don't have to initialize UART
+}
+
+static void virt_serial_putchar(int c) {
+  *UART0 = (uint32_t)c;
+}
+
+SerialPort serial_port = {
+    .init = virt_serial_init,
+    .putchar = virt_serial_putchar,
+};


### PR DESCRIPTION
The implementation of `putchar` may be various in different devices.

We use an platform-independent function `platform_putchar` to replace
the previous codes in `print.cpp`. So we can implement our own `putchar`
function in `src/hw/<specific_device>/port.c` instead of placing all
implementation in `print.cpp`.

In case that we need to initialize the device before using the platform
specific `putchar`, we also provide `platform_putc_init` function.