### PR TITLE
Port BK onto RPi4B

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,9 +32,11 @@ elseif( BP_LOWER STREQUAL "aarch64" )
   include(src/hw/aarch64_virt/CMakeLists.txt)
 elseif( BP_LOWER STREQUAL "thumb" )
   include(src/hw/thumb_lm3s6965evb/CMakeLists.txt)
+elseif( BP_LOWER STREQUAL "raspi4" )
+  include(src/hw/raspi4/CMakeLists.txt)
 else()
   message(FATAL_ERROR "Invalid platform \"${BP_LOWER}\". \
-  Expected one of \"arm\", \"thumb\", \"aarch64\".")
+  Expected one of \"arm\", \"thumb\", \"aarch64\", \"raspi4\".")
 endif()
 
 set( CMAKE_C_COMPILER "${PREFIX}gcc" )

--- a/cmake/AddDemo.cmake
+++ b/cmake/AddDemo.cmake
@@ -28,21 +28,23 @@ function(__add_demo NAME TEST_TYPE MAX_THREADS)
     VERBATIM)
   add_dependencies(make_demos ${NAME})
 
-  add_custom_target(run_${NAME})
-  add_dependencies(run_${NAME} ${NAME})
+  if (NOT BP_LOWER STREQUAL "raspi4")
+    add_custom_target(run_${NAME})
+    add_dependencies(run_${NAME} ${NAME})
 
-  add_custom_command(TARGET run_${NAME} POST_BUILD
-    COMMAND eval "${QEMU}${NAME}"
-   VERBATIM)
+    add_custom_command(TARGET run_${NAME} POST_BUILD
+      COMMAND eval "${QEMU}${NAME}"
+     VERBATIM)
 
-  add_custom_target(debug_${NAME})
-  add_dependencies(debug_${NAME} ${NAME})
+    add_custom_target(debug_${NAME})
+    add_dependencies(debug_${NAME} ${NAME})
 
-  add_custom_command(TARGET debug_${NAME} POST_BUILD
-    COMMAND eval "${QEMU}${NAME} -s -S"
-    VERBATIM)
+    add_custom_command(TARGET debug_${NAME} POST_BUILD
+      COMMAND eval "${QEMU}${NAME} -s -S"
+      VERBATIM)
+  endif()
 
-  if(NOT TEST_TYPE STREQUAL "none")
+  if(NOT TEST_TYPE STREQUAL "none" AND NOT BP_LOWER STREQUAL "raspi4")
     # This could be done with add_test, but then we wouldn't see the failure output.
     add_custom_target(test_${NAME} ALL)
     add_dependencies(test_${NAME} ${NAME})
@@ -67,5 +69,5 @@ function(__add_demo NAME TEST_TYPE MAX_THREADS)
     else()
       message(FATAL_ERROR "Unknown testing type \"${TEST_TYPE}\" for demo \"${NAME}\"")
     endif()
-  endif(NOT TEST_TYPE STREQUAL "none")
+  endif(NOT TEST_TYPE STREQUAL "none" AND NOT BP_LOWER STREQUAL "raspi4")
 endfunction(__add_demo)

--- a/cmake/AddLoadable.cmake
+++ b/cmake/AddLoadable.cmake
@@ -20,6 +20,8 @@ function(__add_loadable PARENT NAME PIE TEST)
   elseif( BP_LOWER STREQUAL "aarch64" )
     # Due to ardp alignment etc., we need more room
     set( CODE_PAGE_SIZE 11264 )
+  elseif( BP_LOWER STREQUAL "raspi4" )
+    set( CODE_PAGE_SIZE 11264 )
   else()
     message(FATAL_ERROR "Can't set CODE_PAGE_SIZE for \"${BP_LOWER}\".")
   endif()

--- a/demos/file/CMakeLists.txt
+++ b/demos/file/CMakeLists.txt
@@ -1,1 +1,6 @@
+# We can not perform file operations without semihosting
+if(NOT SEMIHOSTING)
+  return()
+endif()
+
 add_demo(file 6)

--- a/demos/loadbinaries/CMakeLists.txt
+++ b/demos/loadbinaries/CMakeLists.txt
@@ -1,4 +1,5 @@
-if(LTO)
+# We can not load binary files without semihosting
+if(LTO OR NOT SEMIHOSTING)
   return()
 endif()
 

--- a/demos/loadbinary/CMakeLists.txt
+++ b/demos/loadbinary/CMakeLists.txt
@@ -1,5 +1,6 @@
 # LTO needs us to attribute used a whole bunch of stuff
-if(LTO)
+# We can not load binaries without semihosting
+if(LTO OR NOT SEMIHOSTING)
   return()
 endif()
 

--- a/demos/loadpiebinary/CMakeLists.txt
+++ b/demos/loadpiebinary/CMakeLists.txt
@@ -1,5 +1,6 @@
 # To support LTO we need to attribute used a lot of stuff
-if(LTO)
+# We can not load binaries without semihosting
+if(LTO OR NOT SEMIHOSTING)
   return()
 endif()
 

--- a/demos/shell/CMakeLists.txt
+++ b/demos/shell/CMakeLists.txt
@@ -1,4 +1,5 @@
-if(LTO)
+# We can not perform file operations without semihosting
+if(LTO OR NOT SEMIHOSTING)
   return()
 endif()
 

--- a/include/port/raspi4/gpio.h
+++ b/include/port/raspi4/gpio.h
@@ -1,0 +1,22 @@
+#ifndef PORT_RASPI4_GPIO_H
+#define PORT_RASPI4_GPIO_H
+
+#include "port/raspi4/mmio.h"
+
+#define GPFSEL0 ((volatile unsigned int*)(MMIO_BASE + 0x00200000))
+#define GPFSEL1 ((volatile unsigned int*)(MMIO_BASE + 0x00200004))
+#define GPFSEL2 ((volatile unsigned int*)(MMIO_BASE + 0x00200008))
+#define GPFSEL3 ((volatile unsigned int*)(MMIO_BASE + 0x0020000C))
+#define GPFSEL4 ((volatile unsigned int*)(MMIO_BASE + 0x00200010))
+#define GPFSEL5 ((volatile unsigned int*)(MMIO_BASE + 0x00200014))
+#define GPSET0  ((volatile unsigned int*)(MMIO_BASE + 0x0020001C))
+#define GPSET1  ((volatile unsigned int*)(MMIO_BASE + 0x00200020))
+#define GPCLR0  ((volatile unsigned int*)(MMIO_BASE + 0x00200028))
+#define GPLEV0  ((volatile unsigned int*)(MMIO_BASE + 0x00200034))
+#define GPLEV1  ((volatile unsigned int*)(MMIO_BASE + 0x00200038))
+#define GPEDS0  ((volatile unsigned int*)(MMIO_BASE + 0x00200040))
+#define GPEDS1  ((volatile unsigned int*)(MMIO_BASE + 0x00200044))
+#define GPHEN0  ((volatile unsigned int*)(MMIO_BASE + 0x00200064))
+#define GPHEN1  ((volatile unsigned int*)(MMIO_BASE + 0x00200068))
+
+#endif /* PORT_RASPI4_GPIO_H */

--- a/include/port/raspi4/mbox.h
+++ b/include/port/raspi4/mbox.h
@@ -1,0 +1,26 @@
+#ifndef PORT_RASPI4_MBOX_H
+#define PORT_RASPI4_MBOX_H
+
+#include <stdint.h>
+
+#define MBOX_REQUEST 0
+
+/* channels */
+#define MBOX_CH_POWER 0
+#define MBOX_CH_FB    1
+#define MBOX_CH_VUART 2
+#define MBOX_CH_VCHIQ 3
+#define MBOX_CH_LEDS  4
+#define MBOX_CH_BTNS  5
+#define MBOX_CH_TOUCH 6
+#define MBOX_CH_COUNT 7
+#define MBOX_CH_PROP  8
+
+/* tags */
+#define MBOX_TAG_SETPOWER   0x28001
+#define MBOX_TAG_SETCLKRATE 0x38002
+#define MBOX_TAG_LAST       0
+
+int mbox_call(unsigned char ch, const uint32_t* mbox);
+
+#endif /* PORT_RASPI4_MBOX_H */

--- a/include/port/raspi4/mmio.h
+++ b/include/port/raspi4/mmio.h
@@ -1,0 +1,6 @@
+#ifndef PORT_RASPI4_MMIO_H
+#define PORT_RASPI4_MMIO_H
+
+#define MMIO_BASE 0xFE000000
+
+#endif /* PORT_RASPI4_MMIO_H */

--- a/include/port/raspi4/uart.h
+++ b/include/port/raspi4/uart.h
@@ -1,0 +1,10 @@
+#ifndef PORT_RASPI4_UART_H
+#define PORT_RASPI4_UART_H
+
+void uart_init();
+void uart_send(unsigned int c);
+char uart_getc();
+void uart_puts(char* s);
+void uart_hex(unsigned int c);
+
+#endif /* PORT_RASPI4_UART_H */

--- a/linker/kernel_rpi.ld
+++ b/linker/kernel_rpi.ld
@@ -1,0 +1,47 @@
+ENTRY(_Reset)
+
+SECTIONS {
+ . = 0x80000;
+
+ .text : {
+   KEEP(*(.text.boot))
+   *(.text*)
+   *(.rodata*)
+   . = ALIGN(8); /* align to pointer size (8 for AArch64) */
+   _init_array = . ;
+   *(.init_array*)
+   _einit_array = . ;
+   _etext = . ;
+ }
+
+ .data : {
+   _data = . ;
+   *(.data)
+   *(.thread_vars)
+   _edata = . ;
+ }
+
+ . = ALIGN(16); /* align 16 for AArch64 */
+ . = . + 0xC00; /* 3kB of stack for kernel */
+ stack_top = . ;
+
+ .bss (NOLOAD) : {
+   _bstart = . ;
+   /* Thread structs go first! */
+   *(.thread_structs)
+   /* then the important zero init globals */
+   *(.thread_vars_bss)
+   *(.bss COMMON)
+   /* Putting this first minimises waste on Arm/Thumb due to alignment below */
+   *(.code_page_backing)
+   /* AArch64 PIE requires that programs start on 4k alignemnt for adrp usage. */
+   . = ALIGN(0x1000);
+   /* on the end in case of weird stuff writing beyond */
+   *(.code_page)
+   . = ALIGN(16);
+   _bend = . ;
+ }
+
+ /* Don't need unwinding info on Arm */
+ /DISCARD/ : { *(.ARM.exidx* ) }
+}

--- a/src/hw/driver/raspi4_serial.c
+++ b/src/hw/driver/raspi4_serial.c
@@ -1,0 +1,18 @@
+#include "common/serial_port.h"
+#include "port/raspi4/uart.h"
+#include <stdint.h>
+
+static void rpi_serial_init() {
+  uart_init();
+}
+
+static void rpi_serial_putchar(int c) {
+  if (c == '\n')
+    uart_send('\r');
+  uart_send(c);
+}
+
+SerialPort serial_port = {
+    .init = rpi_serial_init,
+    .putchar = rpi_serial_putchar,
+};

--- a/src/hw/raspi4/CMakeLists.txt
+++ b/src/hw/raspi4/CMakeLists.txt
@@ -1,0 +1,22 @@
+set( KERNEL_SOURCES ${KERNEL_SOURCES}
+  ${CMAKE_SOURCE_DIR}/src/hw/arm_common/port.c
+  ${CMAKE_SOURCE_DIR}/src/hw/arm_common/gic.c
+  ${CMAKE_SOURCE_DIR}/src/hw/driver/raspi4_serial.c
+  ${CMAKE_SOURCE_DIR}/src/hw/raspi4/port.c
+  ${CMAKE_SOURCE_DIR}/src/hw/raspi4/startup.s
+  ${CMAKE_SOURCE_DIR}/src/hw/raspi4/yield.S
+  ${CMAKE_SOURCE_DIR}/src/hw/raspi4/yield.S
+  ${CMAKE_SOURCE_DIR}/src/hw/raspi4/uart.c
+  ${CMAKE_SOURCE_DIR}/src/hw/raspi4/mbox.c
+  ${CMAKE_SOURCE_DIR}/src/hw/raspi4/exception.c
+  ${CMAKE_SOURCE_DIR}/src/hw/raspi4/libs/string.c
+)
+
+set( PREFIX       "aarch64-none-elf-" )
+# -mgerneal-regs-only to generate instructions without using NEON regs
+# -mstrict-align to avoid unaligned memory access
+set( PLATFORM     "-mcpu=cortex-a72 -mgeneral-regs-only -mstrict-align" )
+# O3 LTO UBSAN trace demo needs some extra
+set( STACK_SIZE 3 )
+set( LINKER_SCRIPT "kernel_rpi.ld" )
+set( SEMIHOSTING OFF )

--- a/src/hw/raspi4/exception.c
+++ b/src/hw/raspi4/exception.c
@@ -1,0 +1,107 @@
+#include "port/raspi4/uart.h"
+
+void invalid_entry() {
+  // In case the UART isn't initialized
+  uart_init();
+  uart_puts("[Error] Invalid exception occurred\n");
+
+  // Load and decode the exception
+  unsigned long esr, elr, spsr, far;
+  asm volatile(
+      "mrs %[esr], esr_el1\n\t"
+      "mrs %[elr], elr_el1\n\t"
+      "mrs %[spsr], spsr_el1\n\t"
+      "mrs %[far], far_el1\n\t"
+      : [esr] "=r"(esr), [elr] "=r"(elr), [spsr] "=r"(spsr), [far] "=r"(far)::);
+
+  // Decode exception type (some, not all. See ARM DDI0487G_a chapter D13.2.37)
+  switch (esr >> 26) {
+    case 0b000000:
+      uart_puts("Unknown");
+      break;
+    case 0b000001:
+      uart_puts("Trapped WFI/WFE");
+      break;
+    case 0b001110:
+      uart_puts("Illegal execution");
+      break;
+    case 0b010101:
+      uart_puts("System call");
+      break;
+    case 0b100000:
+      uart_puts("Instruction abort, lower EL");
+      break;
+    case 0b100001:
+      uart_puts("Instruction abort, same EL");
+      break;
+    case 0b100010:
+      uart_puts("Instruction alignment fault");
+      break;
+    case 0b100100:
+      uart_puts("Data abort, lower EL");
+      break;
+    case 0b100101:
+      uart_puts("Data abort, same EL");
+      break;
+    case 0b100110:
+      uart_puts("Stack alignment fault");
+      break;
+    case 0b101100:
+      uart_puts("Floating point");
+      break;
+    default:
+      uart_puts("Unknown");
+      break;
+  }
+  // Decode data abort cause
+  if (esr >> 26 == 0b100100 || esr >> 26 == 0b100101) {
+    uart_puts(", ");
+    switch ((esr >> 2) & 0x3) {
+      case 0:
+        uart_puts("Address size fault");
+        break;
+      case 1:
+        uart_puts("Translation fault");
+        break;
+      case 2:
+        uart_puts("Access flag fault");
+        break;
+      case 3:
+        uart_puts("Permission fault");
+        break;
+    }
+    switch (esr & 0x3) {
+      case 0:
+        uart_puts(" at level 0");
+        break;
+      case 1:
+        uart_puts(" at level 1");
+        break;
+      case 2:
+        uart_puts(" at level 2");
+        break;
+      case 3:
+        uart_puts(" at level 3");
+        break;
+    }
+  }
+
+  // Dump registers
+  uart_puts(":\n  ESR_EL1 ");
+  uart_hex(esr >> 32);
+  uart_hex(esr);
+  uart_puts(" ELR_EL1 ");
+  uart_hex(elr >> 32);
+  uart_hex(elr);
+  uart_puts("\n SPSR_EL1 ");
+  uart_hex(spsr >> 32);
+  uart_hex(spsr);
+  uart_puts(" FAR_EL1 ");
+  uart_hex(far >> 32);
+  uart_hex(far);
+  uart_puts("\n");
+
+  while (1) {
+    // do nothing
+  }
+}

--- a/src/hw/raspi4/libs/string.c
+++ b/src/hw/raspi4/libs/string.c
@@ -1,0 +1,103 @@
+/**
+ * We made our own implementation here because
+ * toolchain-provided implementation contains
+ * some instructions that has a strict rule to use.
+ *
+ * Since we don't set up MMU, it is possible
+ * to trigger data abort by those instruction.
+ * (like DC ZVA, etc.)
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+size_t strlen(const char* s) {
+  size_t len = 0;
+  while (*s != '\0') {
+    len++;
+    s++;
+  }
+  return len;
+}
+
+int strcmp(const char* s1, const char* s2) {
+  while (*s1 == *s2 && *s1 != '\0' && *s2 != '\0') {
+    s1++;
+    s2++;
+  }
+
+  return *s1 - *s2;
+}
+
+int strncmp(const char* s1, const char* s2, size_t len) {
+  while (len > 0) {
+    if (*s1 != *s2) {
+      return *s1 - *s2;
+    }
+
+    if (*s1 == '\0') {
+      break;
+    }
+
+    s1++;
+    s2++;
+    len--;
+  }
+
+  return 0;
+}
+
+char* strncpy(char* dst, const char* src, size_t num) {
+  size_t i = 0;
+  while (i < num && src[i] != '\0') {
+    dst[i] = src[i];
+    i++;
+  }
+
+  if (i < num)
+    dst[i] = '\0';
+  return dst;
+}
+
+void bzero(void* dst, size_t len) {
+  memset(dst, 0, len);
+}
+
+void* memset(void* dst, int ch, size_t len) {
+  uint8_t* d = dst;
+  while (len-- > 0) {
+    *d++ = ch;
+  }
+  return dst;
+}
+
+void* memcpy(void* dst, const void* src, size_t len) {
+  uint8_t* d = dst;
+  const uint8_t* s = src;
+  while (len-- > 0) {
+    *d++ = *s++;
+  }
+  return dst;
+}
+
+void* memmove(void* dst, const void* src, size_t len) {
+  if (len == 0 || dst == src) {
+    // len == 0 or copy to the same place, return immediately
+    return dst;
+  } else if (src < dst) {
+    // copy backward
+    uint8_t* d = dst + len;
+    const uint8_t* s = src + len;
+    while (len-- > 0) {
+      *--d = *--s;
+    }
+  } else if (src > dst) {
+    // copy forward
+    uint8_t* d = dst;
+    const uint8_t* s = src;
+    while (len-- > 0) {
+      *d++ = *s++;
+    }
+  }
+  return dst;
+}

--- a/src/hw/raspi4/mbox.c
+++ b/src/hw/raspi4/mbox.c
@@ -1,0 +1,43 @@
+#include "port/raspi4/mbox.h"
+#include "common/assert.h"
+#include "port/raspi4/mmio.h"
+
+#include <stdint.h>
+
+#define VIDEOCORE_MBOX (MMIO_BASE + 0x0000B880)
+#define MBOX_READ      ((volatile unsigned int*)(VIDEOCORE_MBOX + 0x0))
+#define MBOX_POLL      ((volatile unsigned int*)(VIDEOCORE_MBOX + 0x10))
+#define MBOX_SENDER    ((volatile unsigned int*)(VIDEOCORE_MBOX + 0x14))
+#define MBOX_STATUS    ((volatile unsigned int*)(VIDEOCORE_MBOX + 0x18))
+#define MBOX_CONFIG    ((volatile unsigned int*)(VIDEOCORE_MBOX + 0x1C))
+#define MBOX_WRITE     ((volatile unsigned int*)(VIDEOCORE_MBOX + 0x20))
+#define MBOX_RESPONSE  0x80000000
+#define MBOX_FULL      0x80000000
+#define MBOX_EMPTY     0x40000000
+
+int mbox_call(unsigned char ch, const uint32_t* mbox) {
+  uint32_t r = (uint64_t)mbox | (ch & 0xF);
+
+  /* wait until we can write to the mailbox */
+  do {
+    asm volatile("nop");
+  } while (*MBOX_STATUS & MBOX_FULL);
+
+  /* write the address of our message to the mailbox with channel identifier */
+  *MBOX_WRITE = r;
+
+  /* now wait for the response */
+  while (1) {
+    /* is there a response? */
+    do {
+      asm volatile("nop");
+    } while (*MBOX_STATUS & MBOX_EMPTY);
+
+    /* is it a response to our message? */
+    if (r == *MBOX_READ) {
+      /* is it a valid successful response? */
+      return mbox[1] == MBOX_RESPONSE;
+    }
+  }
+  return 0;
+}

--- a/src/hw/raspi4/port.c
+++ b/src/hw/raspi4/port.c
@@ -1,0 +1,24 @@
+#include "port/port.h"
+#include "common/print.h"
+
+void platform_init_register_context(RegisterContext* regs) {
+  // Run in EL0
+  regs->spsr_el1 = 0;
+}
+
+void print_register_context(const RegisterContext* ctx) {
+  printf("       x0: 0x%16X   x1: 0x%16X  x2: 0x%16X  x3: 0x%16X\n"
+         "       x4: 0x%16X   x5: 0x%16X  x6: 0x%16X  x7: 0x%16X\n"
+         "       x8: 0x%16X   x9: 0x%16X x10: 0x%16X x11: 0x%16X\n"
+         "      x12: 0x%16X  x13: 0x%16X x14: 0x%16X x15: 0x%16X\n"
+         "      x16: 0x%16X  x17: 0x%16X x18: 0x%16X x19: 0x%16X\n"
+         "      x20: 0x%16X  x21: 0x%16X x22: 0x%16X x23: 0x%16X\n"
+         "      x24: 0x%16X  x25: 0x%16X x26: 0x%16X x27: 0x%16X\n"
+         "      x28: 0x%16X  x29: 0x%16X x30: 0x%16X  pc: 0x%16X\n"
+         " spsr_el1: 0x%16X fpsr: 0x%16X\n",
+         ctx->x0, ctx->x1, ctx->x2, ctx->x3, ctx->x4, ctx->x5, ctx->x6, ctx->x7,
+         ctx->x8, ctx->x9, ctx->x10, ctx->x11, ctx->x12, ctx->x13, ctx->x14,
+         ctx->x15, ctx->x16, ctx->x17, ctx->x18, ctx->x19, ctx->x20, ctx->x21,
+         ctx->x22, ctx->x23, ctx->x24, ctx->x25, ctx->x26, ctx->x27, ctx->x28,
+         ctx->x29, ctx->x30, ctx->pc, ctx->spsr_el1, ctx->fpsr);
+}

--- a/src/hw/raspi4/startup.s
+++ b/src/hw/raspi4/startup.s
@@ -1,0 +1,119 @@
+.section ".text.boot"
+
+.globl _Reset
+_Reset:
+  // read cpu id, stop every core that is not core 0
+  mrs x1, mpidr_el1
+  and x1, x1, #3
+  cbz x1, on_core_0
+
+on_other_cores:
+  // cpu id > 0, stop
+  wfe
+  b on_other_cores
+
+on_core_0:
+  // cpu id == 0
+  // set initial stack pointer
+  ldr x1, =stack_top
+
+  // get the current EL
+  mrs x0, CurrentEL
+  and x0, x0, #12 // clear reserved bits
+
+  // branch if we are running at EL2?
+  cmp x0, #12
+  bne at_el2
+
+  // If we are using the default firmware of Raspberry Pi
+  // We should run at EL2 at beginning. The following code
+  // should never be executed. It is just for completeness
+  mov x2, #0x5b1
+  msr scr_el3, x2
+  mov x2, #0x3c9
+  msr spsr_el3, x2
+  adr x2, at_el2
+  msr elr_el3, x2
+  eret
+
+at_el2:
+  // branch if we are running at EL1
+  cmp x0, #4
+  beq at_el1
+
+  msr sp_el1, x1
+
+  // enable CNTP for EL1
+  mrs x0, cnthctl_el2
+  orr x0, x0, #3
+  msr cnthctl_el2, x0
+  msr cntvoff_el2, xzr
+
+  // enable AArch64 in EL1
+  mov x0, #(1 << 31) // AArch64
+  msr hcr_el2, x0
+  mrs x0, hcr_el2
+
+  // We enable FP / SIMD here to make sure that we can
+  // access FPSR register later when saving the PState
+  mov x0, #(3 << 20)
+  msr cpacr_el1, x0
+  isb
+
+  // Setup SCTLR access
+  mov x2, #0x0800
+  movk x2, #0x30d0, lsl #16
+  msr sctlr_el1, x2
+
+  // set up exception handlers
+  ldr x2, =el1_table
+  msr vbar_el1, x2
+
+  // change execution level to EL1
+  mov x2, #0x3c4
+  msr spsr_el2, x2
+  adr x2, at_el1
+  msr elr_el2, x2
+  eret
+
+at_el1:
+  ldr x1, =stack_top
+  mov sp, x1
+
+  // jump to C code, should not return
+  bl entry
+
+  // for failsafe, halt this core too
+  b on_other_cores
+
+.macro ventry label
+  // Each entry should be 128-byte-aligned.
+  // Please have a look at https://developer.arm.com/documentation/100933/0100/AArch64-exception-vector-table
+  .balign 128
+  b \label
+.endm
+
+// Set the least significant 11 bits to 0.
+// Because these bits [10:0] are reserved in vbar.
+// See https://developer.arm.com/documentation/ddi0595/2020-12/AArch64-Registers/VBAR-EL1--Vector-Base-Address-Register--EL1-
+.align 11
+el1_table:
+  ventry invalid_entry // Synchronous EL1t
+  ventry invalid_entry // IRQ EL1t
+  ventry invalid_entry // FIQ EL1t
+  ventry invalid_entry // Error EL1t
+
+  ventry invalid_entry // Synchronous EL1h
+  ventry invalid_entry // IRQ EL1h
+  ventry invalid_entry // FIQ EL1h
+  ventry invalid_entry // Error EL1h
+
+  ventry handle_svc // Synchronous 64-bit EL0
+  ventry invalid_entry // IRQ 64-bit EL0
+  ventry invalid_entry // FIQ 64-bit EL0
+  ventry invalid_entry // Error 64-bit EL0
+
+  ventry invalid_entry // Synchronous 32-bit EL0
+  ventry invalid_entry // IRQ 32-bit EL0
+  ventry invalid_entry // FIQ 32-bit EL0
+  ventry invalid_entry // Error 32-bit EL0

--- a/src/hw/raspi4/uart.c
+++ b/src/hw/raspi4/uart.c
@@ -1,0 +1,87 @@
+#include "port/raspi4/gpio.h"
+#include "port/raspi4/mbox.h"
+#include "port/raspi4/mmio.h"
+
+#include <stdint.h>
+
+/* PL011 UART registers */
+#define UART0_DR   ((volatile unsigned int*)(MMIO_BASE + 0x00201000))
+#define UART0_FR   ((volatile unsigned int*)(MMIO_BASE + 0x00201018))
+#define UART0_IBRD ((volatile unsigned int*)(MMIO_BASE + 0x00201024))
+#define UART0_FBRD ((volatile unsigned int*)(MMIO_BASE + 0x00201028))
+#define UART0_LCRH ((volatile unsigned int*)(MMIO_BASE + 0x0020102C))
+#define UART0_CR   ((volatile unsigned int*)(MMIO_BASE + 0x00201030))
+#define UART0_IMSC ((volatile unsigned int*)(MMIO_BASE + 0x00201038))
+#define UART0_ICR  ((volatile unsigned int*)(MMIO_BASE + 0x00201044))
+
+void uart_init() {
+  // set up the UART clock
+  // see https://github.com/raspberrypi/firmware/wiki/Mailbox-property-interface
+  // for more information
+  uint32_t __attribute__((aligned(16))) m[9];
+  m[0] = 9 * 4; // The size of the message (9 integers)
+  m[1] = MBOX_REQUEST;
+  m[2] = MBOX_TAG_SETCLKRATE; // set clock rate
+  m[3] = 12;                  // the value length
+  m[4] = 8;                   // The clock ID
+  m[5] = 2;                   // UART clock
+  m[6] = 4000000;             // 4Mhz
+  m[7] = 0;                   // clear turbo
+  m[8] = MBOX_TAG_LAST;
+  mbox_call(MBOX_CH_PROP, m);
+
+  // map UART0 to GPIO pins
+  // You can see more information in BCM2711 Peripherals
+  uint32_t r = *GPFSEL1;
+  r &= ~((7 << 12) | (7 << 15)); // gpio14, gpio15 (FSEL14, FSEL15)
+  r |= (4 << 12) | (4 << 15);    // alt0
+  *GPFSEL1 = r;
+
+  *UART0_ICR = 0x7FF; // clear interrupts
+  *UART0_IBRD = 2;    // 115200 baud
+  *UART0_FBRD = 11;
+  *UART0_LCRH = 0x7 << 4; // 8n1, enable FIFOs
+  *UART0_CR = 0x301;      // enable UART0
+}
+
+void uart_send(unsigned int c) {
+  // wait until we can send
+  do {
+    asm volatile("nop");
+  } while (*UART0_FR & 0x20);
+
+  // write the character to the buffer
+  *UART0_DR = c;
+}
+
+char uart_getc() {
+  // wait until something is in the buffer
+  do {
+    asm volatile("nop");
+  } while (*UART0_FR & 0x10);
+
+  // read it and return
+  char r = (char)(*UART0_DR);
+
+  // convert carrige return to newline
+  return r == '\r' ? '\n' : r;
+}
+
+void uart_puts(char* s) {
+  while (*s) {
+    // convert newline to carrige return + newline
+    if (*s == '\n')
+      uart_send('\r');
+    uart_send(*s++);
+  }
+}
+
+void uart_hex(unsigned int d) {
+  for (int c = 28; c >= 0; c -= 4) {
+    // get highest tetrad
+    unsigned int n = (d >> c) & 0xF;
+    // 0-9 => '0'-'9', 10-15 => 'A'-'F'
+    n += n > 9 ? 0x37 : 0x30;
+    uart_send(n);
+  }
+}

--- a/src/hw/raspi4/yield.S
+++ b/src/hw/raspi4/yield.S
@@ -1,0 +1,267 @@
+#include "common/svc_calls.h"
+
+.set TIMER_AMOUNT, 100000
+
+.macro CHECK_SVC code, handler
+  mov x1, #\code
+  cmp x0, x1
+  beq \handler
+.endm
+
+.macro CURRENT_IN_X20_NEXT_IN_X21
+  // Deliberatley callee saved so we can call the scheduler easily
+  ldr x20, =current_thread
+  ldr x21, =next_thread
+.endm
+
+.macro NEXT_EQUAL_CURRENT
+  CURRENT_IN_X20_NEXT_IN_X21
+  ldr x20, [x20]
+  str x20, [x21] // next_thread = current_thread
+.endm
+
+.macro SAVE_CURRENT_THREAD
+  msr SPSel, #0 // Use user stack
+
+  /* Save all registers to user stack */
+  stp x0,  x1,  [sp, #-16]!
+
+  mrs x0, FPSR              // Restore these second to last
+  mrs x1, SPSR_EL1          // so we have temp regs x0/x1 to msr from
+  stp x0, x1,   [sp, #-16]!
+
+  /* Save the PC we are switching from */
+  mrs x1, ELR_EL1
+
+  stp x1,  x2,  [sp, #-16]! // PC included here
+  stp x3,  x4,  [sp, #-16]!
+  stp x5,  x6,  [sp, #-16]!
+  stp x7,  x8,  [sp, #-16]!
+  stp x9,  x10, [sp, #-16]!
+  stp x11, x12, [sp, #-16]!
+  stp x13, x14, [sp, #-16]!
+  stp x15, x16, [sp, #-16]!
+  stp x17, x18, [sp, #-16]!
+  stp x19, x20, [sp, #-16]!
+  stp x21, x22, [sp, #-16]!
+  stp x23, x24, [sp, #-16]!
+  stp x25, x26, [sp, #-16]!
+  stp x27, x28, [sp, #-16]!
+  stp x29, x30, [sp, #-16]!
+
+  CURRENT_IN_X20_NEXT_IN_X21
+
+  /* Save stack pointer */
+  ldr x1, [x20]        // x1 = current_thread
+  mov x3, sp
+  str x3, [x1], #8     // current_thread->stack_ptr=sp
+.endm
+
+.macro DISABLE_TIMER
+  mov x0, #2                 // Disable timer and mask interrupt
+  msr CNTV_CTL_EL0, x0
+.endm
+
+.macro CALL_KERNEL function
+  msr SPSel, #1        // Use kernel's stack
+  bl  \function
+.endm
+
+/* Having this as a seperate handler is easier than
+   finding the exact right register to read.
+   Since I'm not sure what would happen if there
+   were a pending timer int, and we happened to hit
+   an SVC at the same time. We might lose the SVC.
+*/
+.global handle_timer
+handle_timer:
+  SAVE_CURRENT_THREAD
+  DISABLE_TIMER
+
+  /* Set next to NULL to run the scheduler */
+  mov x0, #0
+  ldr x1, =next_thread
+  str x0, [x1] // next_thread = NULL
+
+  b load_next_thread
+
+.global handle_svc
+handle_svc:
+  SAVE_CURRENT_THREAD
+
+  /* See what brought us here. */
+  mrs x0, ESR_EL1
+  lsr x0, x0, #26    // check exception code
+  mov x1, #0x15      // SVC
+  cmp x0, x1
+  beq check_svc
+  b .                // unknown source
+
+check_svc:
+  mrs x0, ESR_EL1    // Reload then check svc code
+  mov x1, #0xFFFF    // mask to get code
+  and x0, x0, x1
+
+  CHECK_SVC svc_thread_switch, load_next_thread
+  CHECK_SVC svc_disable_timer, disable_timer
+  CHECK_SVC svc_enable_timer, enable_timer
+  CHECK_SVC svc_syscall, generic_syscall
+  b .                // unknown SVC
+
+generic_syscall:
+  CALL_KERNEL k_handle_syscall
+  b load_next_thread
+
+enable_timer:
+  mrs x0, CNTVCT_EL0     // Get current count
+  ldr x1, =TIMER_AMOUNT
+  add x1, x0, x1
+  msr CNTV_CVAL_EL0, x1  // New target is some point in the future
+  mov x0, #1
+  msr CNTV_CTL_EL0, x0 // Set enable bit
+  b finalise_timer
+disable_timer:
+  DISABLE_TIMER
+finalise_timer:
+  NEXT_EQUAL_CURRENT
+  b load_next_thread
+
+.global load_first_thread
+load_first_thread:
+  // Kernel calls this so no current thread to save
+  b load_next_thread
+
+load_next_thread:
+  CURRENT_IN_X20_NEXT_IN_X21
+  // If next_thread is null then we need to run the scheduler
+  ldr x6, [x21]        // x0 = next_thread
+  mov x1, #0
+  cmp x6, x1
+  bne actually_load_thread
+
+  // Otherwise pick a new thread and do housekeeping
+  CALL_KERNEL do_scheduler   // This will set next_thread
+  ldr x6, [x21]              // Get new next_thread
+
+actually_load_thread:
+  /* Either we ran the code above, or kernel jumped here
+     to run setup_thread. Either way we want to set EL0_SP */
+  msr SPSel, #0            // Back to user stack
+  str x6, [x20]            // current_thread = next_thread
+  mov x12, #0              // Set next to null for next switch to call scheduler
+  str x12, [x21]           // next_thread = NULL
+  ldr x20, [x20]           // x20 = current_thread
+  ldr x3, [x20], #8        // x3 = current_thread->stack_ptr
+  mov sp, x3
+
+  /* Restore all registers of the new thread
+     (even init state threads have a blank context
+      to restore)
+  */
+  ldp x29, x30, [sp], #16
+  ldp x27, x28, [sp], #16
+  ldp x25, x26, [sp], #16
+  ldp x23, x24, [sp], #16
+  ldp x21, x22, [sp], #16
+  ldp x19, x20, [sp], #16
+  ldp x17, x18, [sp], #16
+  ldp x15, x16, [sp], #16
+  ldp x13, x14, [sp], #16
+  ldp x11, x12, [sp], #16
+  ldp x9,  x10, [sp], #16
+  ldp x7,  x8,  [sp], #16
+  ldp x5,  x6,  [sp], #16
+  ldp x3,  x4,  [sp], #16
+  ldp x1,  x2,  [sp], #16
+
+  /* x1 = restore PC */
+  msr ELR_EL1, x1
+
+  /* This is FPSR/SPSR */
+  ldp x0, x1, [sp], #16
+  msr FPSR, x0
+  msr SPSR_EL1, x1
+
+  /* Actual x0 and x1 */
+  ldp x0, x1, [sp], #16
+
+  eret
+
+.global signal_handler_wrapper
+signal_handler_wrapper:
+  // x0 = signal, x1 = handler
+  blr x1
+  svc svc_thread_switch
+.global signal_handler_wrapper_end
+signal_handler_wrapper_end:
+  nop
+
+.global get_context
+get_context:
+  // x0 = destination pointer
+  stp x19, x20, [x0], #16
+  stp x21, x22, [x0], #16
+  stp x23, x24, [x0], #16
+  stp x25, x26, [x0], #16
+  stp x27, x28, [x0], #16
+  stp x29, x30, [x0], #16
+  mov x1, sp
+  // Default pc is current lr
+  stp x1, x30, [x0], #16
+  ret
+
+.global set_context
+set_context:
+  // x0 = source pointer
+  ldp x19, x20, [x0], #16
+  ldp x21, x22, [x0], #16
+  ldp x23, x24, [x0], #16
+  ldp x25, x26, [x0], #16
+  ldp x27, x28, [x0], #16
+  ldp x29, x30, [x0], #16
+  // pc and sp
+  ldp x1,  x2,  [x0], #16
+  mov sp, x1
+  br x2
+
+.global set_context_from_stack_address
+set_context_from_stack_address:
+  ldp x0, x1, [sp], #16
+  b set_context
+
+.macro SWAP reg1, reg2
+  ldp x1, x2, [x0]
+  stp \reg1, \reg2, [x0], #16
+  mov \reg1, x1
+  mov \reg2, x2
+.endm
+
+.global swap_context
+swap_context:
+  // x0 = location of ctx to swap to
+  SWAP x19, x20
+  SWAP x21, x22
+  SWAP x23, x24
+  SWAP x25, x26
+  SWAP x27, x28
+
+  // Load x29, x30/lr
+  ldp x3, x4, [x0]
+  // Store current
+  stp x29, x30, [x0], #16
+  mov x29, x3
+  // Don't move new lr just yet
+
+  // Load new sp/pc
+  ldp x1, x2, [x0]
+  mov x3, sp
+  // Store current sp/lr (used as the new pc)
+  stp x3, x30, [x0], #16
+  // Now we can set the new lr
+  mov x30, x4
+  // Set new sp
+  mov sp, x1
+
+  // Reset x0 to be arg1 of new function
+  sub x0, x0, #14*8
+  br x2


### PR DESCRIPTION
In this commit, we add `raspi4` as a new build platform and create
a new category in `src/hw/` for raspi4-related implementations.

Since the bare metal way of reading/writing on SD card is still
working [in progress](https://www.raspberrypi.org/forums/viewtopic.php?f=72&t=308089), only the demos that are not related to file
system can be executed.

We also provides part of the functions in <string.h> to avoid
unaligned access from using toolchain-provided functions.

To test on your own Raspberry Pi 4, you can follow the steps in [Set up Raspberry Pi 4 to run AMT](https://hackmd.io/@oscarshiang/amt_setup).